### PR TITLE
Fix right_prompt namespace

### DIFF
--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -14,7 +14,7 @@ function kubectl_status
     return
   end
 
-  set -l ns (kubectl config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.namespace}")
+  set -l ns (kubectl config view -o "jsonpath={.contexts[?(@.name==\"$ctx\")].context.namespace}")
   [ -z $ns ]; and set -l ns 'default'
 
   echo (set_color cyan)$KUBECTL_PROMPT_ICON" "(set_color white)"($ctx$KUBECTL_PROMPT_SEPARATOR$ns)"


### PR DESCRIPTION
The right prompt was always showing the `default` namespace.